### PR TITLE
Issue #1: calculateLineShifts() should be static

### DIFF
--- a/src/cdmpyparser.c
+++ b/src/cdmpyparser.c
@@ -1345,7 +1345,8 @@ void walk( node *                       tree,
 
 
 /* Calculates the line shifts in terms of absolute position */
-void calculateLineShifts( char *  buffer, int *  lineShifts )
+static void
+calculateLineShifts( const char * buffer, int * lineShifts )
 {
     int     absPos = 0;
     char    symbol;


### PR DESCRIPTION
After this change Codimension IDE continues to work. As far as i can tell it is able to properly parse python files.
